### PR TITLE
HAL: Fix some deivce csd_client error

### DIFF
--- a/hal/msm8974/platform.c
+++ b/hal/msm8974/platform.c
@@ -1661,7 +1661,8 @@ snd_device_t platform_get_input_snd_device(void *platform, audio_devices_t out_d
                 goto exit;
             }
         }
-        if (out_device & AUDIO_DEVICE_OUT_EARPIECE) {
+        if (out_device & AUDIO_DEVICE_OUT_EARPIECE ||
+            out_device & AUDIO_DEVICE_OUT_WIRED_HEADPHONE) {
             if (out_device & AUDIO_DEVICE_OUT_EARPIECE &&
                 audio_extn_should_use_handset_anc(channel_count)) {
                 snd_device = SND_DEVICE_IN_AANC_HANDSET_MIC;


### PR DESCRIPTION
After this change:https://github.com/shminer/android_hardware_qcom_audio/commit/844647bb46301afdd6d600f07fa429f8e2aecc88#diff-4a255382fd18fc338e5d6ee776f5d17eL1650, audio hal will select voice speaker dmic or voice speaker qmic as input device when headphone connected if we set fluence type is fluence.
But some device csd client not allowed this acdb settings.
So we need to determine presence of the wired headphone.

This fixd for my LG device csd client.
